### PR TITLE
update letsencrypt.sh with dehydrated, upgrade alpine 3.4 to 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
-FROM alpine:3.4
+FROM alpine:3.6
 
 RUN apk add --update git
-RUN git clone https://github.com/lukas2511/letsencrypt.sh /letsencrypt.sh
+RUN git clone https://github.com/lukas2511/dehydrated /letsencrypt
 
 RUN apk del git pcre expat
 
 RUN apk add openssl curl bash jq
 
-ADD parts/hook.sh /letsencrypt.sh/hooks/cloudflare/hook.sh
+RUN /letsencrypt/dehydrated --register --accept-terms
 
-ADD parts/go.sh /letsencrypt.sh/run.sh
+ADD parts/hook.sh /letsencrypt/hooks/cloudflare/hook.sh
+
+ADD parts/go.sh /letsencrypt/run.sh
 
 ADD parts/dig /usr/local/bin/dig
 
 RUN rm -rf /var/cache/apk/*
 
-ENTRYPOINT /letsencrypt.sh/run.sh
+ENTRYPOINT /letsencrypt/run.sh

--- a/README.MD
+++ b/README.MD
@@ -7,19 +7,19 @@ A docker container which handles letsencrypt certificate creation and renewal. A
 Should be run with:
 
     docker run --rm -it \
-    --name="letsencrypt.sh" \
+    --name="letsencrypt" \
     -e CF_EMAIL='<CLOUDFLARE_EMAIL>' \
     -e CF_KEY='<CLOUDFLARE_KEY>' \
-    -v letsencrypt.sh/accounts:/letsencrypt.sh/accounts \
-    -v letsencrypt.sh/certs:/letsencrypt.sh/certs \
-    -v letsencrypt.sh/domains.txt:/letsencrypt.sh/domains.txt:ro \
+    -v letsencrypt/accounts:/letsencrypt/accounts \
+    -v letsencrypt/certs:/letsencrypt/certs \
+    -v letsencrypt/domains.txt:/letsencrypt/domains.txt:ro \
     tnwhitwell/letsencrypt.sh-cloudflare
 
-The mapped volumes (/letsencrypt.sh/accounts, /letsencrypt.sh/certs, /letsencrypt.sh/domains.txt) should be mapped somewhere static. The certificates will be created in the /certs folder.
+The mapped volumes (/letsencrypt/accounts, /letsencrypt/certs, /letsencrypt/domains.txt) should be mapped somewhere static. The certificates will be created in the /certs folder.
 
 ## Installation
 
-    git pull https://github.com/tnwhitwell/letsencrypt-cloudflare-docker
+    git clone https://github.com/tnwhitwell/letsencrypt-cloudflare-docker
     cd letsencrypt-cloudflare-docker
     cp run.sh.example run.sh
     

--- a/parts/go.sh
+++ b/parts/go.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-cd /letsencrypt.sh
-./letsencrypt.sh -c -g -t dns-01 -k 'hooks/cloudflare/hook.sh'
+cd /letsencrypt
+./dehydrated -c -g -t dns-01 -k 'hooks/cloudflare/hook.sh'

--- a/parts/hook.sh
+++ b/parts/hook.sh
@@ -96,8 +96,27 @@ function unchanged_cert {
   return
 }
 
+function invalid_challenge {
+  return
+}
+
+function request_failure {
+  return
+}
+
+function startup_hook {
+  return
+}
+
+function exit_hook {
+  return
+}
+
 # check environmental vars
 [ -z "$CF_EMAIL" ] && echo "Need to set CF_EMAIL" && exit 1
 [ -z "$CF_KEY" ] && echo "Need to set CF_EMAIL" && exit 1
 
-HANDLER=$1; shift; $HANDLER $@
+HANDLER="$1"; shift
+if [[ "${HANDLER}" =~ ^(deploy_challenge|clean_challenge|deploy_cert|unchanged_cert|invalid_challenge|request_failure|startup_hook|exit_hook)$ ]]; then
+  "$HANDLER" "$@"
+fi

--- a/run.sh.example
+++ b/run.sh.example
@@ -1,8 +1,8 @@
 docker run --rm -it \
-    --name="letsencrypt.sh" \
+    --name="letsencrypt" \
     -e CF_EMAIL='<CLOUDFLARE_EMAIL>' \
     -e CF_KEY='<CLOUDFLARE_KEY>' \
-    -v letsencrypt.sh/accounts:/letsencrypt.sh/accounts \
-    -v letsencrypt.sh/certs:/letsencrypt.sh/certs \
-    -v letsencrypt.sh/domains.txt:/letsencrypt.sh/domains.txt:ro \
+    -v letsencrypt/accounts:/letsencrypt/accounts \
+    -v letsencrypt/certs:/letsencrypt/certs \
+    -v letsencrypt/domains.txt:/letsencrypt/domains.txt:ro \
     tnwhitwell/letsencrypt.sh-cloudflare


### PR DESCRIPTION
Hi, this is just an update so everything functions again. 

1. Updated / renamed any paths which includes `letsencrypt.sh` to `letsencrypt` since it is now renamed to `dehydrated`, except for the docker hub url.
2. Added `dehydrated --register --accept-terms` to Dockerfile
3. Added few methods which recent dehydrated hook requires.
4. Updated alpine version to 3.6
